### PR TITLE
Deprecation notice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## Deprecated
+
+### Please find 1.0 updates in the [1.0-combined](https://github.com/GriddleGriddle/Griddle/tree/1.0-combined) branch.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-## Deprecated
+## :warning: Deprecated :warning:
 
-### Please find 1.0 updates in the [1.0-combined](https://github.com/GriddleGriddle/Griddle/tree/1.0-combined) branch.
+###  Please find 1.0 updates in the [1.0-combined](https://github.com/GriddleGriddle/Griddle/tree/1.0-combined) branch.


### PR DESCRIPTION
Adds note to indicate that progress is now happening in the [1.0-combined](https://github.com/GriddleGriddle/Griddle/tree/1.0-combined) branch on the main `griddle` repo.